### PR TITLE
Updated to EFCore 5.0.15

### DIFF
--- a/src/EntityFrameworkCore.Extensions.Sequences.PostgreSQL/EntityFrameworkCore.Extensions.Sequences.PostgreSQL.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences.PostgreSQL/EntityFrameworkCore.Extensions.Sequences.PostgreSQL.csproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/EntityFrameworkCore.Extensions.Sequences.PostgreSQL/EntityFrameworkCore.Extensions.Sequences.PostgreSQL.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences.PostgreSQL/EntityFrameworkCore.Extensions.Sequences.PostgreSQL.csproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
     </ItemGroup>
 
 </Project>

--- a/src/EntityFrameworkCore.Extensions.Sequences.PostgreSQL/Internal/NpgsqlSequenceTranslator.cs
+++ b/src/EntityFrameworkCore.Extensions.Sequences.PostgreSQL/Internal/NpgsqlSequenceTranslator.cs
@@ -1,38 +1,52 @@
 ﻿namespace EntityFrameworkCore.Extensions.Sequences.PostgreSQL.Internal
 {
-  using System.Collections.Generic;
-  using System.Diagnostics.CodeAnalysis;
-  using System.Linq;
-  using System.Reflection;
-  using Microsoft.EntityFrameworkCore;
-  using Microsoft.EntityFrameworkCore.Query;
-  using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-  using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal;
-  using DbFunctionsExtensions = EntityFrameworkCore.Extensions.Sequences.DbFunctionsExtensions;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using System.Reflection;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Diagnostics;
+    using Microsoft.EntityFrameworkCore.Query;
+    using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+    using Npgsql.EntityFrameworkCore.PostgreSQL.Query;
+    using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal;
+    using DbFunctionsExtensions = EntityFrameworkCore.Extensions.Sequences.DbFunctionsExtensions;
 
-  internal class NpgsqlSequenceTranslator : IMethodCallTranslator
-  {
-    private static readonly MethodInfo MethodLong = typeof(DbFunctionsExtensions)
-      .GetMethod(nameof(DbFunctionsExtensions.NextValLong), new[] {typeof(DbFunctions), typeof(string)});
-
-    private readonly NpgsqlSqlExpressionFactory factory;
-
-    public NpgsqlSequenceTranslator([NotNull] NpgsqlSqlExpressionFactory factory)
+    internal class NpgsqlSequenceTranslator : IMethodCallTranslator
     {
-      this.factory = factory;
-    }
+        private static readonly MethodInfo MethodLong = typeof(DbFunctionsExtensions)
+          .GetMethod(nameof(DbFunctionsExtensions.NextValLong), new[] { typeof(DbFunctions), typeof(string) });
 
-    public SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments)
-    {
-      
-      if (method.Equals(NpgsqlSequenceTranslator.MethodLong))
-      {
-        return this.factory.Function("nextval",
-                                     arguments.Skip(1),
-                                     method.ReturnType);
-      }
+        private readonly NpgsqlSqlExpressionFactory factory;
 
-      return null;
+        public NpgsqlSequenceTranslator([NotNull] NpgsqlSqlExpressionFactory factory)
+        {
+            this.factory = factory;
+        }
+
+        public SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments)
+        {
+
+            if (method.Equals(NpgsqlSequenceTranslator.MethodLong))
+            {
+                return this.factory.Function("nextval",
+                                             arguments.Skip(1),
+                                             method.ReturnType);
+            }
+
+            return null;
+        }
+
+        public SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments, IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        {
+            if (method.Equals(NpgsqlSequenceTranslator.MethodLong))
+            {
+                return this.factory.Function("nextval",
+                                             arguments.Skip(1),
+                                             method.ReturnType);
+            }
+
+            return null;
+        }
     }
-  }
 }

--- a/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/EntityFrameworkCore.Extensions.Sequences.SqlServer.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/EntityFrameworkCore.Extensions.Sequences.SqlServer.csproj
@@ -8,7 +8,7 @@
         <RepositoryUrl>https://github.com/moritzrinow/efcore-sequences</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryType>github</RepositoryType>
-        <PackageVersion>5.0.15.1</PackageVersion>
+        <PackageVersion>5.0.0.1</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/EntityFrameworkCore.Extensions.Sequences.SqlServer.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/EntityFrameworkCore.Extensions.Sequences.SqlServer.csproj
@@ -1,14 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <LangVersion>8</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageProjectUrl>https://github.com/moritzrinow/efcore-sequences</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/moritzrinow/efcore-sequences</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/MapsysInc/efcore-sequences</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/MapsysInc/efcore-sequences</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryType>github</RepositoryType>
-        <PackageVersion>0.0.2</PackageVersion>
+        <PackageVersion>5.0.15.1</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/EntityFrameworkCore.Extensions.Sequences.SqlServer.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/EntityFrameworkCore.Extensions.Sequences.SqlServer.csproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.15" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/EntityFrameworkCore.Extensions.Sequences.SqlServer.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/EntityFrameworkCore.Extensions.Sequences.SqlServer.csproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.9" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.15" />
     </ItemGroup>
 
 </Project>

--- a/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/EntityFrameworkCore.Extensions.Sequences.SqlServer.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/EntityFrameworkCore.Extensions.Sequences.SqlServer.csproj
@@ -4,8 +4,8 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <LangVersion>8</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageProjectUrl>https://github.com/MapsysInc/efcore-sequences</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/MapsysInc/efcore-sequences</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/moritzrinow/efcore-sequences</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/moritzrinow/efcore-sequences</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryType>github</RepositoryType>
         <PackageVersion>5.0.15.1</PackageVersion>

--- a/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/Internal/SqlServerSequenceProvider.cs
+++ b/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/Internal/SqlServerSequenceProvider.cs
@@ -88,7 +88,7 @@
       };
 
       var sql =
-        $"SELECT @result = (NEXT VALUE FOR {name})";
+        $"SELECT @result = (NEXT VALUE FOR [{name}])";
 
       var res = this.context.Database.ExecuteSqlRaw(sql, new object[] {result});
 
@@ -104,7 +104,7 @@
         connection.Open();
       }
 
-      var name = sequence.Schema != null ? $"{sequence.Schema}.{sequence.Name} " : sequence.Name;
+      var name = sequence.Schema != null ? $"[{sequence.Schema}].[{sequence.Name}] " : $"[{sequence.Name}]";
       var start = sequence.StartValue != null ? $"START WITH {sequence.StartValue} " : "";
       var increment = sequence.IncrementBy != null ? $"INCREMENT BY {sequence.IncrementBy} " : "";
       var min = sequence.MinValue != null ? $"MINVALUE {sequence.MinValue} " : "NO MINVALUE ";
@@ -171,7 +171,7 @@
       var cache = update.CacheSize != null ? (update.CacheSize.Value > 0 ? $"CACHE {update.CacheSize}" : "NO CACHE") : "";
 
       var sql =
-        $"ALTER SEQUENCE {name} " +
+        $"ALTER SEQUENCE [{name}] " +
         $"{restart} " +
         $"{increment}" +
         $"{min} " +
@@ -196,7 +196,7 @@
       var sql =
         $"DROP SEQUENCE " +
         (conditionally ? $"IF EXISTS " : "") +
-        $"{name}";
+        $"[{name}]";
 
       var result = this.context.Database.ExecuteSqlRaw(sql);
 
@@ -246,7 +246,7 @@
       };
 
       var sql =
-        $"SELECT @result = (NEXT VALUE FOR {name})";
+        $"SELECT @result = (NEXT VALUE FOR [{name}])";
 
       var res = await this.context.Database.ExecuteSqlRawAsync(sql, new object[] {result}, ct);
 
@@ -271,7 +271,7 @@
       var cache = update.CacheSize != null ? (update.CacheSize.Value > 0 ? $"CACHE {update.CacheSize}" : "NO CACHE") : "";
 
       var sql =
-        $"ALTER SEQUENCE {name} " +
+        $"ALTER SEQUENCE [{name}] " +
         $"{restart} " +
         $"{increment}" +
         $"{min} " +

--- a/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/Internal/SqlServerSequenceTranslator.cs
+++ b/src/EntityFrameworkCore.Extensions.Sequences.SqlServer/Internal/SqlServerSequenceTranslator.cs
@@ -1,104 +1,169 @@
 ﻿namespace EntityFrameworkCore.Extensions.Sequences.SqlServer.Internal
 {
-  using System.Collections.Generic;
-  using System.Diagnostics.CodeAnalysis;
-  using System.Linq;
-  using System.Reflection;
-  using Microsoft.EntityFrameworkCore;
-  using Microsoft.EntityFrameworkCore.Query;
-  using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-  using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
-  using Microsoft.EntityFrameworkCore.Storage;
-  using DbFunctionsExtensions = EntityFrameworkCore.Extensions.Sequences.DbFunctionsExtensions;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using System.Reflection;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Diagnostics;
+    using Microsoft.EntityFrameworkCore.Query;
+    using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+    using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
+    using Microsoft.EntityFrameworkCore.Storage;
+    using DbFunctionsExtensions = EntityFrameworkCore.Extensions.Sequences.DbFunctionsExtensions;
 
-  internal class SqlServerSequenceTranslator : IMethodCallTranslator
-  {
-    private static readonly MethodInfo MethodByte = typeof(DbFunctionsExtensions)
-      .GetMethod(nameof(DbFunctionsExtensions.NextValByte), new[] {typeof(DbFunctions), typeof(string)});
-    
-    private static readonly MethodInfo MethodShort = typeof(DbFunctionsExtensions)
-      .GetMethod(nameof(DbFunctionsExtensions.NextValShort), new[] {typeof(DbFunctions), typeof(string)});
-    
-    private static readonly MethodInfo MethodInt = typeof(DbFunctionsExtensions)
-      .GetMethod(nameof(DbFunctionsExtensions.NextValInt), new[] {typeof(DbFunctions), typeof(string)});
-    
-    private static readonly MethodInfo MethodLong = typeof(DbFunctionsExtensions)
-      .GetMethod(nameof(DbFunctionsExtensions.NextValLong), new[] {typeof(DbFunctions), typeof(string)});
-    
-    private static readonly MethodInfo MethodDec = typeof(DbFunctionsExtensions)
-      .GetMethod(nameof(DbFunctionsExtensions.NextValDec), new[] {typeof(DbFunctions), typeof(string)});
-
-    private readonly ISqlExpressionFactory factory;
-
-    public SqlServerSequenceTranslator([NotNull] ISqlExpressionFactory factory)
+    internal class SqlServerSequenceTranslator : IMethodCallTranslator
     {
-      this.factory = factory;
+        private static readonly MethodInfo MethodByte = typeof(DbFunctionsExtensions)
+          .GetMethod(nameof(DbFunctionsExtensions.NextValByte), new[] { typeof(DbFunctions), typeof(string) });
+
+        private static readonly MethodInfo MethodShort = typeof(DbFunctionsExtensions)
+          .GetMethod(nameof(DbFunctionsExtensions.NextValShort), new[] { typeof(DbFunctions), typeof(string) });
+
+        private static readonly MethodInfo MethodInt = typeof(DbFunctionsExtensions)
+          .GetMethod(nameof(DbFunctionsExtensions.NextValInt), new[] { typeof(DbFunctions), typeof(string) });
+
+        private static readonly MethodInfo MethodLong = typeof(DbFunctionsExtensions)
+          .GetMethod(nameof(DbFunctionsExtensions.NextValLong), new[] { typeof(DbFunctions), typeof(string) });
+
+        private static readonly MethodInfo MethodDec = typeof(DbFunctionsExtensions)
+          .GetMethod(nameof(DbFunctionsExtensions.NextValDec), new[] { typeof(DbFunctions), typeof(string) });
+
+        private readonly ISqlExpressionFactory factory;
+
+        public SqlServerSequenceTranslator([NotNull] ISqlExpressionFactory factory)
+        {
+            this.factory = factory;
+        }
+
+        public virtual SqlExpression Translate(SqlExpression instance,
+          MethodInfo method,
+          IReadOnlyList<SqlExpression> arguments)
+        {
+            if (method.Equals(SqlServerSequenceTranslator.MethodByte) ||
+                method.Equals(SqlServerSequenceTranslator.MethodShort) ||
+                method.Equals(SqlServerSequenceTranslator.MethodInt) ||
+                method.Equals(SqlServerSequenceTranslator.MethodLong) ||
+                method.Equals(SqlServerSequenceTranslator.MethodDec))
+            {
+                var typedArguments = new List<SqlExpression>();
+
+                foreach (var arg in arguments.Skip(1))
+                {
+                    typedArguments.Add(this.factory.ApplyDefaultTypeMapping(arg));
+                }
+
+                if (method.ReturnType == typeof(byte))
+                {
+                    return new NextValueExpression(
+                      this.factory.ApplyDefaultTypeMapping(instance),
+                      typedArguments,
+                      method.ReturnType,
+                      new SqlServerByteTypeMapping(SqlServerSequenceDataTypes.TinyInt));
+                }
+
+                if (method.ReturnType == typeof(short))
+                {
+                    return new NextValueExpression(
+                      this.factory.ApplyDefaultTypeMapping(instance),
+                      typedArguments,
+                      method.ReturnType,
+                      new SqlServerShortTypeMapping(SqlServerSequenceDataTypes.SmallInt));
+                }
+
+                if (method.ReturnType == typeof(int))
+                {
+                    return new NextValueExpression(
+                      this.factory.ApplyDefaultTypeMapping(instance),
+                      typedArguments,
+                      method.ReturnType,
+                      new IntTypeMapping(SqlServerSequenceDataTypes.Int));
+                }
+
+                if (method.ReturnType == typeof(long))
+                {
+                    return new NextValueExpression(
+                      this.factory.ApplyDefaultTypeMapping(instance),
+                      typedArguments,
+                      method.ReturnType,
+                      new IntTypeMapping(SqlServerSequenceDataTypes.BigInt));
+                }
+
+                if (method.ReturnType == typeof(decimal))
+                {
+                    return new NextValueExpression(
+                      this.factory.ApplyDefaultTypeMapping(instance),
+                      typedArguments,
+                      method.ReturnType,
+                      new SqlServerDecimalTypeMapping(SqlServerSequenceDataTypes.Decimal));
+                }
+            }
+
+            return null;
+        }
+
+        public virtual SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments, IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        {
+            if (method.Equals(SqlServerSequenceTranslator.MethodByte) ||
+                method.Equals(SqlServerSequenceTranslator.MethodShort) ||
+                method.Equals(SqlServerSequenceTranslator.MethodInt) ||
+                method.Equals(SqlServerSequenceTranslator.MethodLong) ||
+                method.Equals(SqlServerSequenceTranslator.MethodDec))
+            {
+                var typedArguments = new List<SqlExpression>();
+
+                foreach (var arg in arguments.Skip(1))
+                {
+                    typedArguments.Add(this.factory.ApplyDefaultTypeMapping(arg));
+                }
+
+                if (method.ReturnType == typeof(byte))
+                {
+                    return new NextValueExpression(
+                      this.factory.ApplyDefaultTypeMapping(instance),
+                      typedArguments,
+                      method.ReturnType,
+                      new SqlServerByteTypeMapping(SqlServerSequenceDataTypes.TinyInt));
+                }
+
+                if (method.ReturnType == typeof(short))
+                {
+                    return new NextValueExpression(
+                      this.factory.ApplyDefaultTypeMapping(instance),
+                      typedArguments,
+                      method.ReturnType,
+                      new SqlServerShortTypeMapping(SqlServerSequenceDataTypes.SmallInt));
+                }
+
+                if (method.ReturnType == typeof(int))
+                {
+                    return new NextValueExpression(
+                      this.factory.ApplyDefaultTypeMapping(instance),
+                      typedArguments,
+                      method.ReturnType,
+                      new IntTypeMapping(SqlServerSequenceDataTypes.Int));
+                }
+
+                if (method.ReturnType == typeof(long))
+                {
+                    return new NextValueExpression(
+                      this.factory.ApplyDefaultTypeMapping(instance),
+                      typedArguments,
+                      method.ReturnType,
+                      new IntTypeMapping(SqlServerSequenceDataTypes.BigInt));
+                }
+
+                if (method.ReturnType == typeof(decimal))
+                {
+                    return new NextValueExpression(
+                      this.factory.ApplyDefaultTypeMapping(instance),
+                      typedArguments,
+                      method.ReturnType,
+                      new SqlServerDecimalTypeMapping(SqlServerSequenceDataTypes.Decimal));
+                }
+            }
+
+            return null;
+        }
     }
-
-    public virtual SqlExpression Translate(SqlExpression instance,
-      MethodInfo method,
-      IReadOnlyList<SqlExpression> arguments)
-    {
-      if (method.Equals(SqlServerSequenceTranslator.MethodByte) ||
-          method.Equals(SqlServerSequenceTranslator.MethodShort) ||
-          method.Equals(SqlServerSequenceTranslator.MethodInt) ||
-          method.Equals(SqlServerSequenceTranslator.MethodLong) ||
-          method.Equals(SqlServerSequenceTranslator.MethodDec))
-      {
-        var typedArguments = new List<SqlExpression>();
-
-        foreach (var arg in arguments.Skip(1))
-        {
-          typedArguments.Add(this.factory.ApplyDefaultTypeMapping(arg));
-        }
-
-        if (method.ReturnType == typeof(byte))
-        {
-          return new NextValueExpression(
-            this.factory.ApplyDefaultTypeMapping(instance),
-            typedArguments,
-            method.ReturnType,
-            new SqlServerByteTypeMapping(SqlServerSequenceDataTypes.TinyInt));
-        }
-
-        if (method.ReturnType == typeof(short))
-        {
-          return new NextValueExpression(
-            this.factory.ApplyDefaultTypeMapping(instance),
-            typedArguments,
-            method.ReturnType,
-            new SqlServerShortTypeMapping(SqlServerSequenceDataTypes.SmallInt));
-        }
-        
-        if (method.ReturnType == typeof(int))
-        {
-          return new NextValueExpression(
-            this.factory.ApplyDefaultTypeMapping(instance),
-            typedArguments,
-            method.ReturnType,
-            new IntTypeMapping(SqlServerSequenceDataTypes.Int));
-        }
-        
-        if (method.ReturnType == typeof(long))
-        {
-          return new NextValueExpression(
-            this.factory.ApplyDefaultTypeMapping(instance),
-            typedArguments,
-            method.ReturnType,
-            new IntTypeMapping(SqlServerSequenceDataTypes.BigInt));
-        }
-        
-        if (method.ReturnType == typeof(decimal))
-        {
-          return new NextValueExpression(
-            this.factory.ApplyDefaultTypeMapping(instance),
-            typedArguments,
-            method.ReturnType,
-            new SqlServerDecimalTypeMapping(SqlServerSequenceDataTypes.Decimal));
-        }
-      }
-
-      return null;
-    }
-  }
 }

--- a/src/EntityFrameworkCore.Extensions.Sequences.Test/EntityFrameworkCore.Extensions.Sequences.Test.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences.Test/EntityFrameworkCore.Extensions.Sequences.Test.csproj
@@ -20,8 +20,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.9" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.15" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
     </ItemGroup>
 
 

--- a/src/EntityFrameworkCore.Extensions.Sequences.Test/EntityFrameworkCore.Extensions.Sequences.Test.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences.Test/EntityFrameworkCore.Extensions.Sequences.Test.csproj
@@ -20,8 +20,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.15" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.0" />
     </ItemGroup>
 
 

--- a/src/EntityFrameworkCore.Extensions.Sequences.Test/Startup.cs
+++ b/src/EntityFrameworkCore.Extensions.Sequences.Test/Startup.cs
@@ -31,7 +31,7 @@ namespace EntityFrameworkCore.Extensions.Sequences.Test
       if (this.Configuration.GetValue<bool>("TestOptions:RunTestServices"))
       {
         services.AddTransient<ITestService, SqlServerTest>();
-        services.AddTransient<ITestService, NpgsqlTest>();
+        //services.AddTransient<ITestService, NpgsqlTest>();
         services.AddHostedService<TestSuiteService>();
       }
     }

--- a/src/EntityFrameworkCore.Extensions.Sequences.Test/appsettings.json
+++ b/src/EntityFrameworkCore.Extensions.Sequences.Test/appsettings.json
@@ -9,12 +9,12 @@
   },
   "AllowedHosts": "*",
   "TestOptions": {
-    "RunTestServices": false,
+    "RunTestServices": true,
     "CurrentDatabase": "sqlserver-testdb",
     "Databases": {
       "sqlserver-testdb": {
         "Provider": "sqlserver",
-        "ConnectionString": "connectionString"
+        "ConnectionString": "server=localhost;database=sqlserver-testdb;integrated security=SSPI"
       },
       "npgsql-testdb": {
         "Provider": "npgsql",

--- a/src/EntityFrameworkCore.Extensions.Sequences/EntityFrameworkCore.Extensions.Sequences.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences/EntityFrameworkCore.Extensions.Sequences.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/EntityFrameworkCore.Extensions.Sequences/EntityFrameworkCore.Extensions.Sequences.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences/EntityFrameworkCore.Extensions.Sequences.csproj
@@ -9,7 +9,7 @@
         <RepositoryUrl>https://github.com/moritzrinow/efcore-sequences</RepositoryUrl>
         <RepositoryType>github</RepositoryType>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>5.0.15.1</PackageVersion>
+        <PackageVersion>5.0.0.1</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EntityFrameworkCore.Extensions.Sequences/EntityFrameworkCore.Extensions.Sequences.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences/EntityFrameworkCore.Extensions.Sequences.csproj
@@ -13,8 +13,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.9" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.9" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.15" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.15" />
     </ItemGroup>
 
 </Project>

--- a/src/EntityFrameworkCore.Extensions.Sequences/EntityFrameworkCore.Extensions.Sequences.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences/EntityFrameworkCore.Extensions.Sequences.csproj
@@ -9,7 +9,7 @@
         <RepositoryUrl>https://github.com/moritzrinow/efcore-sequences</RepositoryUrl>
         <RepositoryType>github</RepositoryType>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.0.2</PackageVersion>
+        <PackageVersion>5.0.15.1</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EntityFrameworkCore.Extensions.Sequences/EntityFrameworkCore.Extensions.Sequences.csproj
+++ b/src/EntityFrameworkCore.Extensions.Sequences/EntityFrameworkCore.Extensions.Sequences.csproj
@@ -13,8 +13,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.15" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.15" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/EntityFrameworkCore.Extensions.Sequences/NextValueExpression.cs
+++ b/src/EntityFrameworkCore.Extensions.Sequences/NextValueExpression.cs
@@ -65,10 +65,10 @@
            ? new NextValueExpression(instance, arguments, Type, TypeMapping)
            : this;
 
-    public override void Print(ExpressionPrinter expressionPrinter)
+    protected override void Print(ExpressionPrinter expressionPrinter)
     {
       expressionPrinter.Append(this.Function);
-      expressionPrinter.VisitList(this.Arguments);
+      expressionPrinter.VisitCollection(this.Arguments);
     }
     
     public override bool Equals(object obj)

--- a/src/EntityFrameworkCore.Sequences.sln
+++ b/src/EntityFrameworkCore.Sequences.sln
@@ -12,9 +12,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFrameworkCore.Extensions.Sequences.Test", "EntityFrameworkCore.Extensions.Sequences.Test\EntityFrameworkCore.Extensions.Sequences.Test.csproj", "{DC764EFF-4B56-49CE-86C6-DF11EA24230D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BC724D13-517F-4097-A919-79B2B949639D}"
-	ProjectSection(SolutionItems) = preProject
-		nuget.config = nuget.config
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/EntityFrameworkCore.Sequences.sln
+++ b/src/EntityFrameworkCore.Sequences.sln
@@ -1,12 +1,20 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFrameworkCore.Extensions.Sequences", "EntityFrameworkCore.Extensions.Sequences\EntityFrameworkCore.Extensions.Sequences.csproj", "{9FBF7A6B-A450-4D9E-A61C-58CDEF327718}"
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32328.378
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFrameworkCore.Extensions.Sequences", "EntityFrameworkCore.Extensions.Sequences\EntityFrameworkCore.Extensions.Sequences.csproj", "{9FBF7A6B-A450-4D9E-A61C-58CDEF327718}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFrameworkCore.Extensions.Sequences.SqlServer", "EntityFrameworkCore.Extensions.Sequences.SqlServer\EntityFrameworkCore.Extensions.Sequences.SqlServer.csproj", "{CD0749BF-B1C6-4CD3-8C3D-07A2532BD953}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFrameworkCore.Extensions.Sequences.SqlServer", "EntityFrameworkCore.Extensions.Sequences.SqlServer\EntityFrameworkCore.Extensions.Sequences.SqlServer.csproj", "{CD0749BF-B1C6-4CD3-8C3D-07A2532BD953}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFrameworkCore.Extensions.Sequences.PostgreSQL", "EntityFrameworkCore.Extensions.Sequences.PostgreSQL\EntityFrameworkCore.Extensions.Sequences.PostgreSQL.csproj", "{C64445ED-9E81-45AC-87DA-26EFF827AD5E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFrameworkCore.Extensions.Sequences.PostgreSQL", "EntityFrameworkCore.Extensions.Sequences.PostgreSQL\EntityFrameworkCore.Extensions.Sequences.PostgreSQL.csproj", "{C64445ED-9E81-45AC-87DA-26EFF827AD5E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFrameworkCore.Extensions.Sequences.Test", "EntityFrameworkCore.Extensions.Sequences.Test\EntityFrameworkCore.Extensions.Sequences.Test.csproj", "{DC764EFF-4B56-49CE-86C6-DF11EA24230D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFrameworkCore.Extensions.Sequences.Test", "EntityFrameworkCore.Extensions.Sequences.Test\EntityFrameworkCore.Extensions.Sequences.Test.csproj", "{DC764EFF-4B56-49CE-86C6-DF11EA24230D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BC724D13-517F-4097-A919-79B2B949639D}"
+	ProjectSection(SolutionItems) = preProject
+		nuget.config = nuget.config
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -30,5 +38,11 @@ Global
 		{DC764EFF-4B56-49CE-86C6-DF11EA24230D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DC764EFF-4B56-49CE-86C6-DF11EA24230D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DC764EFF-4B56-49CE-86C6-DF11EA24230D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A707C7CC-13DE-4C98-88E3-4EB02007F001}
 	EndGlobalSection
 EndGlobal

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="mapsys-utilities-nuget" value="https://pkgs.dev.azure.com/AppDevMapsys/_packaging/mapsys-utilities-nuget/nuget/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="mapsys-utilities-nuget" value="https://pkgs.dev.azure.com/AppDevMapsys/_packaging/mapsys-utilities-nuget/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Updated to EFCore 5.x
Tied version number to EFCore version number
Added []'s for SqlServer name's to support sequences with -'s or other special characters

(I didn't test with Postgres, as I don't have that installed, but SqlServer tests passed)